### PR TITLE
Add repository field to package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   },
   "author": "Felix Jung <jung.felix@gmail.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/felixjung/contentful-utils.git"
+  },
   "dependencies": {
     "contentful-management": "^1.3.0",
     "lodash": "^4.17.2",


### PR DESCRIPTION
Currently when checking [this package on npm](https://www.npmjs.com/package/contentful-utils) there is no link to GitHub included which makes it hard to evaluate the project. :)

Adding the `repository` property should fix this.