### PR TITLE
Remove duplicate field args to commands

### DIFF
--- a/lib/sub-commands/copy-fields.js
+++ b/lib/sub-commands/copy-fields.js
@@ -8,12 +8,13 @@ const {
 function copyFields(options) {
   const {source: sourceId, target, fields: fieldIds = []} = options
   const targetIds = _.concat([], target)
+  const uniqueFieldIds = _.uniq(fieldIds)
 
   log.info(`Copying fields ${fieldIds.join(', ')} from Content Type ${sourceId} to Content Types ${targetIds.join(', ')}`)
 
   return getSpace(options)
     .then(space => space.getContentTypes())
-    .then(_.partialRight(copyFieldsToTargets, sourceId, fieldIds, targetIds, options))
+    .then(_.partialRight(copyFieldsToTargets, sourceId, uniqueFieldIds, targetIds, options))
     .catch(handleContentTypesRejection)
 }
 

--- a/lib/sub-commands/delete-fields.js
+++ b/lib/sub-commands/delete-fields.js
@@ -7,13 +7,14 @@ const {
 
 function deleteFields(options) {
   const {target, fields: fieldIds} = options
+  const uniqueFieldIds = _.uniq(fieldIds)
   const targetIds = _.concat([], target)
 
   log.info(`Deleting fields ${fieldIds.join(', ')} from Content Type(s) ${targetIds.join(', ')}.`)
 
   return getSpace(options)
     .then(space => space.getContentTypes())
-    .then(_.partialRight(deleteFieldsFromContentTypes, fieldIds, targetIds, options))
+    .then(_.partialRight(deleteFieldsFromContentTypes, uniqueFieldIds, targetIds, options))
     .catch(handleContentTypesRejection)
 }
 


### PR DESCRIPTION
When passing multiple fields as args to any of the commands, one might run into unnecessary problems when providing the same field multiple times. This PR addresses the problem, but the solution is not very nice. Will try to find something nicer in a future refactor. 