### PR TITLE
Allow overwriting a field when using 'copy-fields' command

### DIFF
--- a/lib/content-types.js
+++ b/lib/content-types.js
@@ -1,32 +1,37 @@
 const log = require('npmlog')
 const _ = require('lodash')
 const inquirer = require('inquirer')
+const Bluebird = require('bluebird')
 
-function addFields(
+async function addFields(
   contentType, fields, {update = true, publish = false} = {}
 ) {
   const existingFields = _.get(contentType, 'fields', [])
-  const updatedFields = _.reduce(fields, (accFields, field) =>
-    addField(accFields, field), _.concat([], existingFields))
 
-  log.info(`Adding fields ${getFieldNames(fields)} to Content Type ${contentType.name}.`)
-  contentType.fields = updatedFields
+  try {
+    const updatedFields = await Bluebird.reduce(fields, (accFields, field) =>
+      addField(accFields, field), _.concat([], existingFields))
 
-  if (update) {
-    log.info(`Updating Content Type ${contentType.name} on Contentful.`)
-    contentType.update().then(() => {
-      log.info(`COMPLETE: Updated Content Type ${contentType.name}`)
-    })
+    log.info(`Adding fields ${getFieldNames(fields)} to Content Type ${contentType.name}.`)
+    contentType.fields = updatedFields
+
+    if (update) {
+      log.info(`Updating Content Type ${contentType.name} on Contentful.`)
+      contentType.update().then(() => {
+        log.info(`COMPLETE: Updated Content Type ${contentType.name}`)
+      })
+    }
+
+    if (publish) {
+      log.info(`Publishing Content Type ${contentType.name} to Contentful.`)
+      contentType.publish().then(() => {
+        log.info(`COMPLETE: Published Content Type ${contentType.name}`)
+      })
+    }
+    return contentType
+  } catch (err) {
+    console.error(err)
   }
-
-  if (publish) {
-    log.info(`Publishing Content Type ${contentType.name} to Contentful.`)
-    contentType.publish().then(() => {
-      log.info(`COMPLETE: Published Content Type ${contentType.name}`)
-    })
-  }
-
-  return contentType
 }
 
 function getFieldNames(fields) {
@@ -34,7 +39,7 @@ function getFieldNames(fields) {
 }
 
 async function addField(fields, field) {
-  const existingField = _.find(fields, 'id')
+  const existingField = _.find(fields, {id: field.id})
 
   if (!existingField) {
     return _.concat(fields, field)
@@ -42,14 +47,18 @@ async function addField(fields, field) {
 
   // Handle the existing field
 
-  const shouldOverwrite = await inquirer.prompt([{
-    type: 'confirm',
-    name: 'overwrite',
-    message: `Field ${field.id} already exists. Overwrite?`
-  }])
+  try {
+    const {overwrite} = await inquirer.prompt([{
+      type: 'confirm',
+      name: 'overwrite',
+      message: `Field ${field.id} already exists. Overwrite?`
+    }])
 
-  if (!shouldOverwrite) {
-    return fields
+    if (!overwrite) {
+      return fields
+    }
+  } catch (err) {
+    console.error('Inquirer failed')
   }
 
   // Check if fields are compatible (i.e. Array vs. non-array type field)
@@ -94,7 +103,7 @@ function omitFields(contentType, fieldIds) {
 
   if (fieldsUnchanged) {
     log.warn(`Fields unchanged. Doing nothing...`)
-    return Promise.resolve(contentType)
+    return Bluebird.resolve(contentType)
   }
 
   contentType.fields = mappedFields
@@ -122,7 +131,7 @@ function deleteFields(contentType, fieldIds) {
 
   if (fieldsUnchanged) {
     log.warn(`Fields unchanged. Doing nothing...`)
-    return Promise.resolve(contentType)
+    return Bluebird.resolve(contentType)
   }
 
   contentType.fields = mappedFields

--- a/lib/content-types.js
+++ b/lib/content-types.js
@@ -1,5 +1,6 @@
 const log = require('npmlog')
 const _ = require('lodash')
+const inquirer = require('inquirer')
 
 function addFields(
   contentType, fields, {update = true, publish = false} = {}
@@ -32,16 +33,42 @@ function getFieldNames(fields) {
   return _.map(fields, field => field.name).join(', ')
 }
 
-function addField(fields, field) {
-  const hasField = _.findIndex(fields, f => f.id === field.id) > -1
+async function addField(fields, field) {
+  const existingField = _.find(fields, 'id')
 
-  if (hasField) {
-    log.error(`Field ${field.name} already exists. Delete it first`)
-    log.error('Skipping...')
+  if (!existingField) {
+    return _.concat(fields, field)
+  }
+
+  // Handle the existing field
+
+  const shouldOverwrite = await inquirer.prompt([{
+    type: 'confirm',
+    name: 'overwrite',
+    message: `Field ${field.id} already exists. Overwrite?`
+  }])
+
+  if (!shouldOverwrite) {
     return fields
   }
 
-  return _.concat(fields, field)
+  // Check if fields are compatible (i.e. Array vs. non-array type field)
+  const sameType = existingField.type === field.type
+
+  if (!sameType) {
+    return fields
+  }
+
+  const isArrayType = field.type === 'Array'
+  const incompatibleArrays = isArrayType && field.items.type !== existingField.items.type
+
+  if (incompatibleArrays) {
+    return fields
+  }
+
+  // Overwrite content type
+  const otherFields = _.reject(fields, existingField)
+  return _.concat(otherFields, field)
 }
 
 function getFields(contentType, fieldIds) {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "git+https://github.com/felixjung/contentful-utils.git"
   },
   "dependencies": {
+    "bluebird": "^3.5.0",
     "contentful-management": "^1.3.0",
     "inquirer": "^3.0.6",
     "lodash": "^4.17.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "contentful-management": "^1.3.0",
+    "inquirer": "^3.0.6",
     "lodash": "^4.17.2",
     "npmlog": "^4.0.1",
     "yargs": "^6.5.0"


### PR DESCRIPTION
A likely scenario:

- Update configuration of a field on one content type.
- Attempt to get that same field configuration on a different content type with the same field via `copy-fields`.
- contentful-utils would skip the field because it already exists on the target content type.

This PR introduces inquirer to allow users overwriting the existing field configuration on the target via a prompt. It will still refuse to overwrite the target field configuration, if the source and target fields are incompatible (i.e. one is a collection the other is not or they have different type).

This addresses #9 